### PR TITLE
Remove JS processing altogether

### DIFF
--- a/lib/helpers/memoized.js
+++ b/lib/helpers/memoized.js
@@ -32,4 +32,3 @@ exports.walkData            = helpers.walkData
 exports.isTemplate          = helpers.isTemplate
 exports.isStylesheet        = helpers.isStylesheet
 exports.isJavaScript        = helpers.isJavaScript
-exports.needsBrowserify      = helpers.needsBrowserify

--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -496,14 +496,3 @@ exports.isJavaScript = function(filePath){
 
   return processors["js"].indexOf(ext) !== -1
 }
-
-/**
- * needsBrowserify
- *
- * returns true if the code uses require, exports or module but doesn't declare them
- */
-
-exports.needsBrowserify = function(source) {
-	return /^[^#\/'"*]*(require|module|exports)\b/m.test(source)
-		&& !(/\b(function|var|global) +(require|module|exports)\b|\b(module|require) *=[^=]/.test(source))
-}

--- a/lib/javascript/index.js
+++ b/lib/javascript/index.js
@@ -39,6 +39,7 @@ module.exports = function(root, filePath, callback){
 
     var exceptionHandler = function(err) {
       success = false
+      console.log(err.message)
       const error = new TerraformError({
         source: ext,
         dest: "JavaScript",
@@ -50,7 +51,6 @@ module.exports = function(root, filePath, callback){
       })
       callback(error)
     }
-
     process.once('uncaughtException', exceptionHandler)
     browserify(srcPath, {extensions: extensions}).transform('coffeeify').transform('babelify')
     .on('error', exceptionHandler).bundle()

--- a/lib/javascript/index.js
+++ b/lib/javascript/index.js
@@ -51,9 +51,18 @@ module.exports = function(root, filePath, callback){
       })
       callback(error)
     }
+
     process.once('uncaughtException', exceptionHandler)
-    browserify(srcPath, {extensions: extensions}).transform('coffeeify').transform('babelify')
-    .on('error', exceptionHandler).bundle()
+
+    /**
+     * Pass all JS through browserify -> coffeeify -> babelify
+     */
+
+    browserify(srcPath, {extensions: extensions})
+    .transform('coffeeify', {bare: false, header: true})
+    .on('error', exceptionHandler)
+    .transform('babelify')
+    .bundle()
     .on('data', function(buf) {
       if (success) {
         post += buf
@@ -61,6 +70,10 @@ module.exports = function(root, filePath, callback){
     }).on('end', function() {
       if (success) {
         process.removeListener('uncaughtException', exceptionHandler)
+
+        /**
+         * Consistently minify
+         */
         callback(null, minify.js(post, minifyOpts))
       }
     })

--- a/lib/javascript/index.js
+++ b/lib/javascript/index.js
@@ -4,21 +4,12 @@ var helpers    = require('../helpers')
 var minify  = require('harp-minify')
 var browserify = require('browserify')
 var through    = require('through')
+var TerraformError = require("../error").TerraformError
 
-/**
- * Build Processor list for javascripts.
- *
- * same as doing...
- *
- *    var processors = {
- *      "coffee" : require("./processors/coffee")
- *    }
- *
- */
- var extensions = [], processors = {}
+
+var extensions = []
 helpers.processors["js"].forEach(function(sourceType){
   extensions.push('.' + sourceType)
-  processors[sourceType] = require("./processors/" + sourceType)
 })
 
 module.exports = function(root, filePath, callback){
@@ -44,62 +35,35 @@ module.exports = function(root, filePath, callback){
 
     if(err) return callback(err)
 
-    /**
-     * Lookup Directories
-     */
+    var post = '', success = true
 
-    var render = function(ext, data, cb) {
-      processors[ext].compile(srcPath, data, function(err, js) {
-        if (err) return cb(err)
-
-        /**
-         * Consistently minify
-         */
-        cb(null, minify.js(js, minifyOpts))
+    var exceptionHandler = function(err) {
+      success = false
+      const error = new TerraformError({
+        source: ext,
+        dest: "JavaScript",
+        name: "Browserify Error",
+        message: err.message,
+        filename: err.filename,
+        stack: err.annotated,
+        lineno: err.line
       })
+      callback(error)
     }
 
-    if(helpers.needsBrowserify(data.toString())) {
-      var post = '', success = true
-
-      var exceptionHandler = function(err) {
-        success = false
-        console.log(err.message)
-        render(ext, data, callback)
+    process.once('uncaughtException', exceptionHandler)
+    browserify(srcPath, {extensions: extensions}).transform('coffeeify').transform('babelify')
+    .on('error', exceptionHandler).bundle()
+    .on('data', function(buf) {
+      if (success) {
+        post += buf
       }
-
-      process.once('uncaughtException', exceptionHandler)
-      browserify(srcPath, {extensions: extensions}).transform(function(file) {
-        var result = ''
-        return through(write, end)
-
-        function write(buf) {
-          result += buf
-        }
-        function end() {
-          if(success) {
-            var that = this
-            render(path.extname(file).replace(/^\./, '').toLowerCase(), result, function(err, data) {
-              that.queue(data)
-              that.queue(null)
-            })
-          }
-        }
-      }).on('error', exceptionHandler).bundle()
-      .on('data', function(buf) {
-        if (success) {
-          post += buf
-        }
-      }).on('end', function() {
-        if (success) {
-          process.removeListener('uncaughtException', exceptionHandler)
-          callback(null, minify.js(post, minifyOpts))
-        }
-      })
-    }
-    else {
-      render(ext, data, callback)
-    }
+    }).on('end', function() {
+      if (success) {
+        process.removeListener('uncaughtException', exceptionHandler)
+        callback(null, minify.js(post, minifyOpts))
+      }
+    })
 
   })
 

--- a/lib/javascript/processors/coffee.js
+++ b/lib/javascript/processors/coffee.js
@@ -1,4 +1,0 @@
-// This file is intentionally left blank. It signifies
-// that .coffee files are supported, but actual
-// transformation occurs in our main browserify
-// call.

--- a/lib/javascript/processors/coffee.js
+++ b/lib/javascript/processors/coffee.js
@@ -1,20 +1,4 @@
-var cs = require("coffee-script")
-var TerraformError = require("../../error").TerraformError
-
-exports.compile = function(filePath, fileContents, callback){
-  try{
-    var errors = null
-    var script = cs.compile(fileContents.toString(), { bare: true })
-  }catch(e){
-    var errors = e
-    errors.source = "CoffeeScript"
-    errors.dest = "JavaScript"
-    errors.filename = filePath
-    errors.stack = fileContents.toString()
-    errors.lineno = parseInt(errors.location.first_line ? errors.location.first_line + 1 : -1)
-    var script = null
-    var error = new TerraformError(errors)
-  }finally{
-    callback(error, script)
-  }
-}
+// This file is intentionally left blank. It signifies
+// that .coffee files are supported, but actual
+// transformation occurs in our main browserify
+// call.

--- a/lib/javascript/processors/js.js
+++ b/lib/javascript/processors/js.js
@@ -1,4 +1,0 @@
-// This file is intentionally left blank. It signifies
-// that .js files are supported, but actual
-// transformation occurs in our main browserify
-// call.

--- a/lib/javascript/processors/js.js
+++ b/lib/javascript/processors/js.js
@@ -1,3 +1,4 @@
-exports.compile = function(filePath, fileContents, callback){
-	callback(null, fileContents.toString())
-}
+// This file is intentionally left blank. It signifies
+// that .js files are supported, but actual
+// transformation occurs in our main browserify
+// call.

--- a/lib/terraform.js
+++ b/lib/terraform.js
@@ -55,7 +55,6 @@ exports.root = function(root, globals){
      */
 
     render: function(filePath, locals, callback){
-
       // get rid of leading slash (windows)
       filePath = filePath.replace(/^\\/g, '')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "pre-processor engine that powers the harp web server",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "3.10.1",
     "lru-cache": "4.0.0",
     "marked": "0.3.5",
-    "node-sass": "3.4.2",
+    "node-sass": "3.7.0",
     "postcss": "5.0.14",
     "stylus": "0.53.0",
     "through": "2.3.8"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "autoprefixer": "6.2.3",
     "browserify": "12.0.1",
-    "coffee-script": "1.10.0",
+    "babelify": "7.3.0",
+    "coffeeify": "2.0.1",
     "ejs": "2.3.4",
     "harp-minify": "0.4.0",
     "jade": "1.11.0",

--- a/test/errors.js
+++ b/test/errors.js
@@ -189,7 +189,7 @@ describe("errors", function(){
       poly.render("coffee/invalid.coffee", function(error, body){
         should.not.exist(body)
         should.exist(error)
-        error.should.have.property('source', "CoffeeScript")
+        error.should.have.property('source', "coffee")
         error.should.have.property('dest', "JavaScript")
         error.should.have.property('lineno', 3)
         error.should.have.property('filename')


### PR DESCRIPTION
I finally got back to this, comparing what I'd done to what you have in this branch—there's not much difference—I just deleted the `js` processors and added a couple of comments. I get strangely inconsistent results when running tests however: the coffeescript tests fail occasionally on "should skip commented require" and _every time_ on "should error with invalid file". This varies depending on where the error handler is placed (I'll put a line note).

Interestingly, in the current `HEAD` of the original repo the `js.js` file is already gone, partially mirroring what we discussed; but `.coffee` is still being processed separately... I wonder if the `coffeeify` transform is a bridge too far here?
