### PR TITLE
Remove JS `processor` files

### DIFF
--- a/lib/javascript/index.js
+++ b/lib/javascript/index.js
@@ -51,9 +51,18 @@ module.exports = function(root, filePath, callback){
       })
       callback(error)
     }
+
     process.once('uncaughtException', exceptionHandler)
-    browserify(srcPath, {extensions: extensions}).transform('coffeeify').transform('babelify')
-    .on('error', exceptionHandler).bundle()
+
+    /**
+     * Pass all JS through browserify -> coffeeify -> babelify
+     */
+
+    browserify(srcPath, {extensions: extensions})
+    .transform('coffeeify', {bare: false, header: true})
+    .on('error', exceptionHandler)
+    .transform('babelify')
+    .bundle()
     .on('data', function(buf) {
       if (success) {
         post += buf
@@ -61,6 +70,10 @@ module.exports = function(root, filePath, callback){
     }).on('end', function() {
       if (success) {
         process.removeListener('uncaughtException', exceptionHandler)
+
+        /**
+         * Consistently minify
+         */
         callback(null, minify.js(post, minifyOpts))
       }
     })

--- a/lib/javascript/processors/coffee.js
+++ b/lib/javascript/processors/coffee.js
@@ -1,4 +1,0 @@
-// This file is intentionally left blank. It signifies
-// that .coffee files are supported, but actual
-// transformation occurs in our main browserify
-// call.

--- a/lib/javascript/processors/js.js
+++ b/lib/javascript/processors/js.js
@@ -1,4 +1,0 @@
-// This file is intentionally left blank. It signifies
-// that .js files are supported, but actual
-// transformation occurs in our main browserify
-// call.


### PR DESCRIPTION
I finally got back to this, comparing what I'd done to what you have in this branch—there's not much difference—I just deleted the `js` processors and added a couple of comments. I get strangely inconsistent results when running tests however: the coffeescript tests fail occasionally on "should skip commented require" and _every time_ on "should error with invalid file". This varies depending on where the error handler is placed (I'll put a line note).

Interestingly, in the current `HEAD` of the original repo the `js.js` file is already gone, partially mirroring what we discussed; but `.coffee` is still being processed separately... I wonder if the `coffeeify` transform is a bridge too far here?
